### PR TITLE
添加 buildSrc/settings.gradle.kts 以更改镜像

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        maven(url = "https://mirrors.huaweicloud.com/repository/maven")
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
目前 `buildSrc` 目录下没有 `settings.gradle.kts`，用的是默认的镜像，速度实在感人。看其他几个文件里用的是华为云的，就在这里同样用了华为云。